### PR TITLE
IE8 compatibility fix: use _.indexOf() for arrays instead of .indexOf()

### DIFF
--- a/lib/sub_manager.js
+++ b/lib/sub_manager.js
@@ -57,7 +57,7 @@ SubsManager.prototype._addSub = function(args) {
   var sub = self._cacheMap[hash];
   sub.updated = (new Date).getTime();
 
-  var index = self._cacheList.indexOf(sub);
+  var index = _.indexOf(self._cacheList, sub);
   self._cacheList.splice(index, 1);
   self._cacheList.push(sub);
 };


### PR DESCRIPTION
SubsManager unfortunately completely kills subscriptions for IE8 at the moment due to using indexOf on an array which isn't supported. This hopefully fixes it! :)